### PR TITLE
Fix BFF background slide visibility

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  puppeteer: set this to true or false
+  puppeteer: true
 minimumReleaseAgeExclude:
   - svelteup@5.2.1

--- a/styles/index.css
+++ b/styles/index.css
@@ -53,6 +53,7 @@ textarea,
 }
 
 .reveal .slides {
+  background: transparent;
   text-align: left;
 }
 


### PR DESCRIPTION
## Summary
- make the Reveal slide canvas transparent so `data-background-image` slides are not covered
- approve the existing pnpm puppeteer build config so local/CI installs can complete

## Verification
- `PNPM_HOME=/Users/merchant/.slock/agents/965616d4-d561-46e7-8e57-d273236e908f/.pnpm-home pnpm run build`
- agent-browser check: `http://127.0.0.1:4173/bff.html#/2` now shows the architecture image
